### PR TITLE
cast django.utils.dates gettext_lazy to str

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -1146,7 +1146,7 @@ def rule_to_text(rule, short=False):
             -3: _('3rd last'),
             -4: _('4th last'),
         }
-        weekdays_display = list(dates.WEEKDAYS_ABBR.values())
+        weekdays_display = list(map(str, dates.WEEKDAYS_ABBR.values()))
         months_display = [date.capitalize() for date in dates.MONTHS_3.values()]
 
     else:
@@ -1166,8 +1166,8 @@ def rule_to_text(rule, short=False):
             -3: _('third last'),
             -4: _('fourth last'),
         }
-        weekdays_display = list(dates.WEEKDAYS.values())
-        months_display = list(dates.MONTHS.values())
+        weekdays_display = list(map(str, dates.WEEKDAYS.values()))
+        months_display = list(map(str, dates.MONTHS.values()))
 
     def get_positional_weekdays(rule):
         items = []

--- a/recurrence/static/recurrence/css/recurrence.css
+++ b/recurrence/static/recurrence/css/recurrence.css
@@ -2,12 +2,12 @@ textarea.recurrence-widget {
   display: none;
 }
 div.recurrence-widget {
-  background-color: var(--body-bg);
-  border: 1px solid var(--border-color);
+  background-color: var(--dj-recurrence-body-bg);
+  border: 1px solid var(--dj-recurrence-border-color);
 }
 
 div.recurrence-widget div.panel {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--dj-recurrence-border-color);
   display: flex;
   flex-direction: column;
 }
@@ -41,7 +41,7 @@ div.recurrence-widget .remove:visited {
   font-weight: bold;
   cursor: pointer;
   text-decoration: none;
-  color: var(--body-quiet-color);
+  color: var(--dj-recurrence-body-quiet-color);
   line-height: 1.4em;
   background-color: transparent;
   border: none;
@@ -77,7 +77,7 @@ div.recurrence-widget .interval {
 
 div.recurrence-widget .dtstart {
   padding: 1em 0;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--dj-recurrence-border-color);
 }
 
 div.recurrence-widget .dtstart .dtstart-date {
@@ -86,7 +86,7 @@ div.recurrence-widget .dtstart .dtstart-date {
 
 div.recurrence-widget .limit {
   padding: 1em 0 0 0;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--dj-recurrence-border-color);
 }
 
 div.recurrence-widget .limit ul {
@@ -128,7 +128,7 @@ div.recurrence-widget .weekday-grid {
 }
 
 div.recurrence-widget .weekday-grid .weekday {
-  background: var(--body-bg);
+  background: var(--dj-recurrence-body-bg);
   padding: 10px 15px;
   border: none;
   border-radius: 4px;
@@ -155,14 +155,14 @@ div.recurrence-widget .section {
 
 div.recurrence-widget .grid {
   border: 0;
-  border-top: 1px solid var(--border-color);
-  border-left: 1px solid var(--border-color);
+  border-top: 1px solid var(--dj-recurrence-border-color);
+  border-left: 1px solid var(--dj-recurrence-border-color);
 }
 
 div.recurrence-widget .grid td {
   text-align: center;
-  border-bottom: 1px solid var(--border-color);
-  border-right: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--dj-recurrence-border-color);
+  border-right: 1px solid var(--dj-recurrence-border-color);
   padding: .8em;
   cursor: pointer;
   transition: all 0.15s;
@@ -202,7 +202,7 @@ div.recurrence-widget .date-value {
 div.recurrence-widget form {
     overflow: hidden;
     padding: .5em 2.2em;
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid var(--dj-recurrence-border-color);
 }
 
 div.recurrence-widget .form {

--- a/recurrence/static/recurrence/js/recurrence-widget.js
+++ b/recurrence/static/recurrence/js/recurrence-widget.js
@@ -367,20 +367,18 @@ recurrence.widget.RuleForm.prototype = {
     };
 
     if (showRRuleEnd) {
-      const count_value = this.rule.count ? this.rule.count : 1;
-      this.update_count_text(count_value);
+      // const count_value = this.rule.count ? this.rule.count : 1;
+      // this.update_count_text(count_value);
 
       if (this.options.isNew) {
         const defaultEnd = form.panel.widget.options.defaultEnd;
         if (defaultEnd) {
           if (defaultEnd == 'COUNT') {
-            count_radio.checked = true;
+            count_radio.onclick();
           } else if (defaultEnd == 'UNTIL') {
-            until_radio.checked = true;
-            form.set_until(until_date_selector.value);
+            until_radio.onclick();
           } else if (defaultEnd == 'NEVER') {
-            never_radio.checked = true;
-            form.set_count(parseInt(count_field.value), 10);
+            never_radio.onclick();
           }
         }
       }


### PR DESCRIPTION
Fix for `TypeError: sequence item 0: expected str instance, __proxy__ found'`
django.utils.dates uses `gettext_lazy` while all the other definitions use `gettext`.

--------

The recurrence rule always sets count to 0, even when if defaultEnd is "NEVER"

---------

changed css file from generic css variables to package specific css variables



